### PR TITLE
fix: using a more network friendly url

### DIFF
--- a/oss-test/src/main/java/dev/ocpd/oss/FileStoreTest.java
+++ b/oss-test/src/main/java/dev/ocpd/oss/FileStoreTest.java
@@ -21,7 +21,7 @@ public abstract class FileStoreTest {
 
     static {
         try {
-            TEST_FILE_URL = new URL("https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png");
+            TEST_FILE_URL = new URL("https://www.bing.com/msasignin/cobranding/logo");
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException("Invalid test file URL", e);
         }


### PR DESCRIPTION
Using the Google logo is not very web-friendly, so we can choose to use the Microsoft Bing logo instead.
