### PR TITLE
fix: duplicated dependencyManagement tag issue

### DIFF
--- a/oss-s3/build.gradle.kts
+++ b/oss-s3/build.gradle.kts
@@ -3,11 +3,16 @@ plugins {
     id("conventions.publishing")
 }
 
+dependencyManagement {
+    imports {
+        mavenBom(libs.aws.sdk.bom.get().toString())
+    }
+}
+
 dependencies {
     implementation(libs.slf4k)
 
     api(project(":oss-common"))
-    implementation(platform(libs.aws.sdk.bom))
     implementation("software.amazon.awssdk:s3")
 
     api("org.springframework.boot:spring-boot-starter")


### PR DESCRIPTION
Fix [this](https://github.com/ocpddev/oss/actions/runs/5506876258/jobs/10036115430) issue.

see
https://github.com/spring-gradle-plugins/dependency-management-plugin/issues/257
https://github.com/jfrog/build-info/issues/198

fwd @Charm-Xin 