### PR TITLE
feat: use the `DefaultCredentialsProvider` when `accessKey` or `secretKey` are not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ For AWS S3:
 oss:
   provider: s3
   s3:
+    # If the access-key and secret-key is not set, the default credential provider will be used
     access-key: <your-access-key>
     secret-key: <your-secret-key>
     region: <your-region>

--- a/oss-s3/src/main/java/dev/ocpd/oss/config/AwsS3FileStoreAutoConfiguration.kt
+++ b/oss-s3/src/main/java/dev/ocpd/oss/config/AwsS3FileStoreAutoConfiguration.kt
@@ -11,6 +11,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
@@ -27,12 +28,15 @@ class AwsS3FileStoreAutoConfiguration(
     private val awsCredentialsProvider: AwsCredentialsProvider = createCredentialsProvider()
 
     private fun createCredentialsProvider(): AwsCredentialsProvider {
-        return StaticCredentialsProvider.create(
-            AwsBasicCredentials.create(
-                awsS3Properties.accessKey,
-                awsS3Properties.secretKey
-            )
-        )
+        val accessKey = awsS3Properties.accessKey
+        val secretKey = awsS3Properties.secretKey
+
+        // Use DefaultCredentialsProvider if no access key and secret key are provided
+        if (accessKey == null || secretKey == null) {
+            return DefaultCredentialsProvider.create()
+        }
+
+        return StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey))
     }
 
     private fun buildS3Client(): S3Client {

--- a/oss-s3/src/main/java/dev/ocpd/oss/config/AwsS3Properties.kt
+++ b/oss-s3/src/main/java/dev/ocpd/oss/config/AwsS3Properties.kt
@@ -5,8 +5,8 @@ import java.net.URI
 
 @ConfigurationProperties("oss.s3")
 data class AwsS3Properties(
-    val accessKey: String,
-    val secretKey: String,
+    val accessKey: String?,
+    val secretKey: String?,
     val region: String,
     val bucket: String,
     val endpoint: URI?


### PR DESCRIPTION
The `DefaultCredentialsProvider` offers multiple authentication methods. We utilize it when the accessKey or secretKey is not provided.

What's `DefaultCredentialsProvider` support
```
Java System Properties - aws.accessKeyId and aws.secretAccessKey
Environment Variables - AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
Web Identity Token credentials from system properties or environment variables
Credential profiles file at the default location (~/.aws/credentials) shared by all AWS SDKs and the AWS CLI
Credentials delivered through the Amazon EC2 container service if AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" environment variable is set and security manager has permission to access the variable,
Instance profile credentials delivered through the Amazon EC2 metadata service
```