### PR TITLE
feat: add mv, sizeOf, generateUploadUrl for FileStore

### DIFF
--- a/oss-common/src/main/kotlin/dev/ocpd/oss/FileStore.kt
+++ b/oss-common/src/main/kotlin/dev/ocpd/oss/FileStore.kt
@@ -80,7 +80,7 @@ interface FileStore {
      * @param dest   The key of the file to be moved to.
      * @return True if the file is moved successfully, false otherwise.
      */
-    fun mv(source: String, dest: String): Boolean
+    fun move(source: String, dest: String): Boolean
 
     /**
      * Get the size of a file.

--- a/oss-common/src/main/kotlin/dev/ocpd/oss/FileStore.kt
+++ b/oss-common/src/main/kotlin/dev/ocpd/oss/FileStore.kt
@@ -74,6 +74,23 @@ interface FileStore {
     fun exists(key: String): Boolean
 
     /**
+     * Move a file from one key to another.
+     *
+     * @param source The key of the file to be moved.
+     * @param dest   The key of the file to be moved to.
+     * @return True if the file is moved successfully, false otherwise.
+     */
+    fun mv(source: String, dest: String): Boolean
+
+    /**
+     * Get the size of a file.
+     *
+     * @param key The key of the file.
+     * @return The size of the file.
+     */
+    fun sizeOf(key: String): Long
+
+    /**
      * Generate the signed url for downloading a file.
      * Note: The url can only be used to download the file, not for uploading or other operations. The url will be expired after the specified seconds.
      *
@@ -91,5 +108,25 @@ interface FileStore {
      */
     fun generateDownloadUrl(key: String): URL {
         return generateDownloadUrl(key, 600)
+    }
+
+    /**
+     * Generate the signed url for uploading a file.
+     * Note: The url can only be used to uploading the file, not for download or other operations. The url will be expired after the specified seconds.
+     *
+     * @param key           The key of the file.
+     * @param expirySeconds The seconds before the url expires.
+     * @return The signed url.
+     */
+    fun generateUploadUrl(key: String, expirySeconds: Long): URL
+
+    /**
+     * Generate the signed url for uploading a file. The url will be expired after 10 minutes.
+     *
+     * @param key The key of the file.
+     * @return The signed url.
+     */
+    fun generateUploadUrl(key: String): URL {
+        return generateUploadUrl(key, 60)
     }
 }

--- a/oss-common/src/testFixtures/kotlin/dev/ocpd/oss/FileStoreContract.kt
+++ b/oss-common/src/testFixtures/kotlin/dev/ocpd/oss/FileStoreContract.kt
@@ -123,7 +123,7 @@ interface FileStoreContract<T : FileStore> {
             Files.copy(it, tempFile, StandardCopyOption.REPLACE_EXISTING)
             fileStore.upload(TEST_FILE_KEY, tempFile)
             val newKey = "$TEST_FILE_KEY_PREFIX/binglogo2.png"
-            fileStore.mv(TEST_FILE_KEY, newKey)
+            fileStore.move(TEST_FILE_KEY, newKey)
             val fileExist = fileStore.exists(newKey)
             assertTrue(fileExist)
         }

--- a/oss-common/src/testFixtures/kotlin/dev/ocpd/oss/FileStoreContract.kt
+++ b/oss-common/src/testFixtures/kotlin/dev/ocpd/oss/FileStoreContract.kt
@@ -6,7 +6,12 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.net.URI
 import java.net.URL
+import java.net.http.HttpClient.newHttpClient
+import java.net.http.HttpRequest.BodyPublishers
+import java.net.http.HttpRequest.newBuilder
+import java.net.http.HttpResponse.BodyHandlers
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 
@@ -15,7 +20,7 @@ interface FileStoreContract<T : FileStore> {
     companion object {
         private const val TEST_FILE_KEY_PREFIX = "oss-test-images"
         private const val TEST_FILE_KEY = "$TEST_FILE_KEY_PREFIX/binglogo.png"
-        private val TEST_FILE_URL: URL = URL("https://www.bing.com/msasignin/cobranding/logo")
+        private val TEST_FILE_URL: URL = URI("https://www.bing.com/msasignin/cobranding/logo").toURL()
     }
 
     val fileStore: T
@@ -110,6 +115,34 @@ interface FileStoreContract<T : FileStore> {
     }
 
     @Test
+    @DisplayName("should be able to move file")
+    fun move() {
+        val tempFile = Files.createTempFile("binglogo", ".png")
+
+        TEST_FILE_URL.openStream().use {
+            Files.copy(it, tempFile, StandardCopyOption.REPLACE_EXISTING)
+            fileStore.upload(TEST_FILE_KEY, tempFile)
+            val newKey = "$TEST_FILE_KEY_PREFIX/binglogo2.png"
+            fileStore.mv(TEST_FILE_KEY, newKey)
+            val fileExist = fileStore.exists(newKey)
+            assertTrue(fileExist)
+        }
+
+        Files.delete(tempFile)
+    }
+
+    @Test
+    @DisplayName("should be able to get file size")
+    fun sizeOf() {
+        TEST_FILE_URL.openStream().use {
+            val fileContent = it.readAllBytes()
+            fileStore.upload(TEST_FILE_KEY, fileContent)
+            val fileSize = fileStore.sizeOf(TEST_FILE_KEY)
+            assertEquals(fileContent.size.toLong(), fileSize)
+        }
+    }
+
+    @Test
     @DisplayName("should be able to download via signed url")
     fun generateDownloadUrl() {
         val tempFile = Files.createTempFile("binglogo", ".png")
@@ -122,6 +155,26 @@ interface FileStoreContract<T : FileStore> {
             os.use { signedUrl.openStream().use { ins -> ins.transferTo(os) } }
 
             assertArrayEquals(Files.readAllBytes(tempFile), os.toByteArray())
+        }
+
+        Files.delete(tempFile)
+    }
+
+    @Test
+    @DisplayName("should be able to upload via signed url")
+    fun generateUploadUrl() {
+        val tempFile = Files.createTempFile("binglogo", ".png")
+
+        TEST_FILE_URL.openStream().use {
+            Files.copy(it, tempFile, StandardCopyOption.REPLACE_EXISTING)
+            val signedUrl = fileStore.generateUploadUrl(TEST_FILE_KEY)
+            // use http client to upload
+            newHttpClient().send(
+                newBuilder(signedUrl.toURI()).PUT(BodyPublishers.ofFile(tempFile)).build(),
+                BodyHandlers.ofString()
+            )
+            val fileContent = fileStore.downloadAsBytes(TEST_FILE_KEY)
+            assertArrayEquals(Files.readAllBytes(tempFile), fileContent)
         }
 
         Files.delete(tempFile)

--- a/oss-gcs/src/main/kotlin/dev/ocpd/oss/GcsFileStore.kt
+++ b/oss-gcs/src/main/kotlin/dev/ocpd/oss/GcsFileStore.kt
@@ -76,7 +76,7 @@ class GcsFileStore(
         return storage[bucket, key] != null
     }
 
-    override fun mv(source: String, dest: String): Boolean {
+    override fun move(source: String, dest: String): Boolean {
         val sourceBlob = storage[bucket, source] ?: return false
         sourceBlob.copyTo(bucket, dest)
         sourceBlob.delete()

--- a/oss-gcs/src/test/kotlin/dev/ocpd/oss/GcsFileStoreTest.kt
+++ b/oss-gcs/src/test/kotlin/dev/ocpd/oss/GcsFileStoreTest.kt
@@ -18,4 +18,8 @@ class GcsFileStoreTest(
     override fun generateDownloadUrl() {
         //Disable this test because it is not supported by fake-gcs-server
     }
+
+    override fun generateUploadUrl() {
+        //Disable this test because it is not supported by fake-gcs-server
+    }
 }

--- a/oss-s3/src/main/kotlin/dev/ocpd/oss/AwsS3FileStore.kt
+++ b/oss-s3/src/main/kotlin/dev/ocpd/oss/AwsS3FileStore.kt
@@ -110,7 +110,7 @@ class AwsS3FileStore(
         }
     }
 
-    override fun mv(source: String, dest: String): Boolean {
+    override fun move(source: String, dest: String): Boolean {
         return try {
             client.copyObject { it.sourceBucket(bucket).sourceKey(source).destinationBucket(bucket).destinationKey(dest) }
             client.deleteObject { it.bucket(bucket).key(source) }

--- a/oss-s3/src/main/kotlin/dev/ocpd/oss/AwsS3FileStore.kt
+++ b/oss-s3/src/main/kotlin/dev/ocpd/oss/AwsS3FileStore.kt
@@ -110,11 +110,38 @@ class AwsS3FileStore(
         }
     }
 
+    override fun mv(source: String, dest: String): Boolean {
+        return try {
+            client.copyObject { it.sourceBucket(bucket).sourceKey(source).destinationBucket(bucket).destinationKey(dest) }
+            client.deleteObject { it.bucket(bucket).key(source) }
+            true
+        } catch (e: NoSuchKeyException) {
+            false
+        }
+    }
+
+    /**
+     * @return The size of the file in bytes.
+     */
+    override fun sizeOf(key: String): Long {
+        return client.headObject { it.bucket(bucket).key(key) }.contentLength()
+    }
+
     override fun generateDownloadUrl(key: String, expirySeconds: Long): URL {
         val presignedGetRequest = s3Presigner.presignGetObject {
             it.getObjectRequest { innerBuilder -> innerBuilder.bucket(bucket).key(key) }
                 .signatureDuration(Duration.ofSeconds(expirySeconds))
         }
         return presignedGetRequest.url()
+    }
+
+    override fun generateUploadUrl(key: String, expirySeconds: Long): URL {
+        val presignedPutRequest = s3Presigner.presignPutObject {
+            it.putObjectRequest { innerBuilder ->
+                innerBuilder.bucket(bucket).key(key)
+            }.signatureDuration(Duration.ofSeconds(expirySeconds))
+        }
+        return presignedPutRequest.url()
+
     }
 }


### PR DESCRIPTION
## Description

Add `mv`, `sizeof`, and `generateUploadUrl` for FileStore and its implementation.

## Additional

- New tests have been added and all pass in my local environment.
- Use `URI.toURL` instead of `new URL()` as `new URL()` has been deprecated since JDK 20.