### PR TITLE
build(deps): migrate gradle/wrapper-validation-action@v2 to gradle/actions/wrapper-validation@v3

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -17,4 +17,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: gradle/actions/wrapper-validation@v3


### PR DESCRIPTION
This PR migrates `gradle/wrapper-validation-action@v2` to `gradle/actions/wrapper-validation@v3`

In `v3`, `gradle/wrapper-validation-action@v3` will transparently delegate to `gradle/actions/wrapper-validation@v3`

For more details, can visit: 
- https://github.com/gradle/wrapper-validation-action
- https://github.com/gradle/actions/blob/main/README.md#the-wrapper-validation-action



> As of `v3` this action has been superceded by `gradle/actions/wrapper-validation`.
> Any workflow that uses `gradle/wrapper-validation-action@v3` will transparently delegate to `gradle/actions/wrapper-validation@v3`.
>
> Users are encouraged to update their workflows, replacing:
> ```
> uses: gradle/wrapper-validation-action@v3
> ```
>
> with
> ```
> uses: gradle/actions/wrapper-validation@v3
> ```
>
> See the [wrapper-validation documentation](https://github.com/gradle/actions/tree/main/wrapper-validation) for up-to-date documentation for `gradle/actions/wrapper-validation`. 



Link: https://github.com/ocpddev/oss/pull/245